### PR TITLE
Fixing issue 52 - removed .example.env

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,2 +1,0 @@
-NEXT_PUBLIC_GOOGLE_ANALYTICS=G-sample
-FAVICON=/prixite.github.io

--- a/env.sample
+++ b/env.sample
@@ -1,1 +1,2 @@
+#NEXT_PUBLIC_GOOGLE_ANALYTICS=G-sample
 FAVICON=/prixite.github.io


### PR DESCRIPTION
I have removed the .example.env file, but have copied and commented out the first env variable into the env.sample file in case it was needed. 